### PR TITLE
Display incoming heals with LibClassicHealComm

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -16,6 +16,9 @@ externals:
         url: https://github.com/ascott18/LibSpellRange-1.0.git
     libs/LibClassicDurations:
         url: https://repos.curseforge.com/wow/libclassicdurations
+    libs/LibClassicHealComm-1.0:
+        url: https://github.com/Aviana/LibClassicHealComm-1.0.git
+        tag: master
     options/libs/AceConfig-3.0:
         url: https://repos.wowace.com/wow/ace3/trunk/AceConfig-3.0
     options/libs/AceDBOptions-3.0:

--- a/ShadowedUnitFrames.lua
+++ b/ShadowedUnitFrames.lua
@@ -311,8 +311,6 @@ function ShadowUF:LoadUnitDefaults()
 
 			if( unit ~= "battleground" and unit ~= "battlegroundpet" and unit ~= "arena" and unit ~= "arenapet" and unit ~= "boss" ) then
 				self.defaults.profile.units[unit].incHeal = {enabled = true, cap = 1.20}
-				self.defaults.profile.units[unit].incAbsorb = {enabled = true, cap = 1.30}
-				self.defaults.profile.units[unit].healAbsorb = {enabled = true, cap = 1.30}
 			end
 		end
 

--- a/ShadowedUnitFrames.toc
+++ b/ShadowedUnitFrames.toc
@@ -5,7 +5,7 @@
 ## Version: @project-version@
 ## SavedVariables: ShadowedUFDB
 ## X-Website: https://www.wowace.com/addons/shadowed-unit-frames/
-## OptionalDeps: Ace3, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets, LibSpellRange-1.0, LibClassicDurations, Clique, RealMobHealth
+## OptionalDeps: Ace3, LibSharedMedia-3.0, AceGUI-3.0-SharedMediaWidgets, LibSpellRange-1.0, LibClassicDurations, LibClassicHealComm-1.0, Clique, RealMobHealth
 ## X-Curse-Project-ID: 19268
 ## X-WoWI-ID: 13494
 
@@ -16,6 +16,7 @@ libs\LibSharedMedia-3.0\lib.xml
 libs\AceDB-3.0\AceDB-3.0.xml
 libs\LibSpellRange-1.0\lib.xml
 libs\LibClassicDurations\LibClassicDurations.xml
+libs\LibClassicHealComm-1.0\lib.xml
 #@end-no-lib-strip@
 
 localization\enUS.lua
@@ -39,6 +40,7 @@ modules\defaultlayout.lua
 modules\highlight.lua
 modules\tags.lua
 modules\health.lua
+modules\incheal.lua
 modules\power.lua
 modules\portrait.lua
 modules\indicators.lua

--- a/modules/defaultlayout.lua
+++ b/modules/defaultlayout.lua
@@ -174,8 +174,6 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 		static = {r = 0.70, g = 0.20, b = 0.90},
 		yellow = {r = 0.93, g = 0.93, b = 0.0},
 		inc = {r = 0, g = 0.35, b = 0.23},
-		incAbsorb = {r = 0.93, g = 0.75, b = 0.09},
-		healAbsorb = {r = 0.68, g = 0.47, b = 1},
 		enemyUnattack = {r = 0.60, g = 0.20, b = 0.20},
 		hostile = {r = 0.90, g = 0.0, b = 0.0},
 		friendly = {r = 0.20, g = 0.90, b = 0.20},

--- a/modules/defaultlayout.lua
+++ b/modules/defaultlayout.lua
@@ -386,7 +386,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			attribAnchorPoint = "LEFT",
 			offset = 20,
 			altPower = {enabled = false},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			auras = {
 				buffs = {enabled = true, maxRows = 1, perRow = 8},
 				debuffs = {enabled = true, maxRows = 1, perRow = 8},
@@ -405,7 +405,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			width = 90,
 			height = 25,
 			scale = 1.0,
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			powerBar = {height = 0.60},
 			text = {
 				{text = "[name]"},
@@ -419,7 +419,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			width = 90,
 			height = 25,
 			scale = 1.0,
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			powerBar = {height = 0.60},
 			text = {
 				{text = "[name]"},
@@ -464,7 +464,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			scale = 1.0,
 			powerBar = {height = 0.60},
 			altPower = {enabled = false},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			text = {
 				{text = "[name]"},
 				{text = "[curhp]"},
@@ -479,7 +479,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			scale = 1.0,
 			powerBar = {height = 0.60},
 			altPower = {enabled = false},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			indicators = {
 				pvp = {anchorTo = "$parent", anchorPoint = "BL", size = 22, x = 0, y = 11},
 			},
@@ -498,7 +498,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			scale = 1.0,
 			powerBar = {height = 0.60},
 			altPower = {enabled = false},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			indicators = {
 				pvp = {anchorTo = "$parent", anchorPoint = "BL", size = 22, x = 0, y = 11},
 			},
@@ -522,7 +522,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			powerBar = {height = 0.5},
 			altPower = {enabled = false},
 			castBar = {order = 60},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			offset = 0,
 			auras = {
 				buffs = {enabled = false, maxRows = 1, perRow = 9},
@@ -546,7 +546,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			scale = 1.0,
 			powerBar = {height = 0.60},
 			altPower = {enabled = false},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			text = {
 				{text = "[name]"},
 				{text = "[curhp]"},
@@ -562,7 +562,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			scale = 1.0,
 			powerBar = {height = 0.60},
 			altPower = {enabled = false},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			indicators = {
 				pvp = {anchorTo = "$parent", anchorPoint = "BL", size = 22, x = 0, y = 11},
 			},
@@ -581,7 +581,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			scale = 1.0,
 			powerBar = {height = 0.60},
 			altPower = {enabled = false},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			indicators = {
 				pvp = {anchorTo = "$parent", anchorPoint = "BL", size = 22, x = 0, y = 11},
 			},
@@ -688,7 +688,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			width = 150,
 			height = 40,
 			scale = 1.0,
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			auras = {
 				buffs = {enabled = false},
 				debuffs = {enabled = false},
@@ -706,7 +706,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			width = 150,
 			height = 40,
 			scale = 1.0,
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			auras = {
 				buffs = {enabled = false},
 				debuffs = {enabled = false},
@@ -724,7 +724,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			width = 90,
 			height = 25,
 			scale = 1.0,
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			powerBar = {height = 0.60},
 			text = {
 				{text = "[name]"},
@@ -739,7 +739,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			height = 25,
 			scale = 1.0,
 			powerBar = {height = 0.60},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			indicators = {
 				pvp = {anchorTo = "$parent", anchorPoint = "BL", size = 22, x = 0, y = 11},
 			},
@@ -757,7 +757,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			height = 25,
 			scale = 1.0,
 			powerBar = {height = 0.60},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			indicators = {
 				pvp = {anchorTo = "$parent", anchorPoint = "BL", size = 22, x = 0, y = 11},
 			},
@@ -799,7 +799,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			height = 30,
 			scale = 1.0,
 			powerBar = {height = 0.70},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			healthBar = {reactionType = "none"},
 			portrait = {enabled = false, fullAfter = 50},
 			castBar = {order = 60},
@@ -819,7 +819,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			width = 190,
 			height = 30,
 			scale = 1.0,
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			powerBar = {height = 0.70},
 			indicators = {
 			},
@@ -837,7 +837,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			height = 30,
 			scale = 1.0,
 			powerBar = {height = 0.6},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			portrait = {alignment = "RIGHT"},
 			indicators = {
 				pvp = {anchorTo = "$parent", anchorPoint = "BL", size = 22, x = -3, y = 11},
@@ -856,7 +856,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			height = 30,
 			scale = 1.0,
 			powerBar = {height = 0.6},
-			healAbsorb = {cap = 1},
+			incHeal = {cap = 1},
 			portrait = {alignment = "RIGHT"},
 			indicators = {
 				pvp = {anchorTo = "$parent", anchorPoint = "BL", size = 22, x = -3, y = 11},

--- a/modules/incheal.lua
+++ b/modules/incheal.lua
@@ -31,8 +31,7 @@ function IncHeal:OnLayoutApplied(frame)
 	bar:SetReverseFill(frame.healthBar:GetReverseFill())
 	bar:Hide()
 
-	-- TODO: Add option n settings for this value
-	local cap = 1.30
+	local cap = ShadowUF.db.profile.units[frame.unitType].incHeal.cap or 1.20
 
 	-- When we can cheat and put the incoming bar right behind the health bar, we can efficiently show the incoming heal bar
 	-- if the main bar has a transparency set, then we need a more complicated method to stop the health bar from being darker with incoming heals up
@@ -88,16 +87,13 @@ function IncHeal:PositionBar(frame, incAmount)
 		return
 	end
 
-	-- TODO: Add option n settings for this value
-	local cap = 1.30
-
 	if( not bar.total ) then bar:Show() end
 	bar.total = incAmount
 
 	-- When the primary bar has an alpha of 100%, we can cheat and do incoming heals easily. Otherwise we need to do it a more complex way to keep it looking good
 	if( bar.simple ) then
 		bar.total = health + incAmount
-		bar:SetMinMaxValues(0, maxHealth * cap)
+		bar:SetMinMaxValues(0, maxHealth * (ShadowUF.db.profile.units[frame.unitType].incHeal.cap or 1.20))
 		bar:SetValue(bar.total)
 	else
 		local healthSize = bar.healthSize * (health / maxHealth)

--- a/modules/incheal.lua
+++ b/modules/incheal.lua
@@ -1,0 +1,130 @@
+local IncHeal = {}
+ShadowUF:RegisterModule(IncHeal, "incHeal", ShadowUF.L["Incoming heals"])
+
+function IncHeal:OnEnable(frame)
+	frame.incHeal = frame.incHeal or ShadowUF.Units:CreateBar(frame)
+
+	frame:RegisterUnitEvent("UNIT_MAXHEALTH", self, "UpdateFrame")
+	frame:RegisterUnitEvent("UNIT_HEALTH", self, "UpdateFrame")
+	frame:RegisterUnitEvent("UNIT_HEALTH_FREQUENT", self, "UpdateFrame")
+
+	frame:RegisterUpdateFunc(self, "UpdateFrame")
+end
+
+function IncHeal:OnDisable(frame)
+	frame:UnregisterAll(self)
+	frame.incHeal:Hide()
+end
+
+function IncHeal:OnLayoutApplied(frame)
+	local bar = frame.incHeal
+	if( not frame.visibility.incHeal or not frame.visibility.healthBar ) then return end
+
+	-- Since we're hiding, reset state
+	bar.total = nil
+
+	bar:SetSize(frame.healthBar:GetSize())
+	bar:SetStatusBarTexture(ShadowUF.Layout.mediaPath.statusbar)
+	bar:SetStatusBarColor(ShadowUF.db.profile.healthColors.inc.r, ShadowUF.db.profile.healthColors.inc.g, ShadowUF.db.profile.healthColors.inc.b, ShadowUF.db.profile.bars.alpha)
+	bar:GetStatusBarTexture():SetHorizTile(false)
+	bar:SetOrientation(frame.healthBar:GetOrientation())
+	bar:SetReverseFill(frame.healthBar:GetReverseFill())
+	bar:Hide()
+
+	-- TODO: Add option n settings for this value
+	local cap = 1.30
+
+	-- When we can cheat and put the incoming bar right behind the health bar, we can efficiently show the incoming heal bar
+	-- if the main bar has a transparency set, then we need a more complicated method to stop the health bar from being darker with incoming heals up
+	if( ( ShadowUF.db.profile.units[frame.unitType].healthBar.invert and ShadowUF.db.profile.bars.backgroundAlpha == 0 ) or ( not ShadowUF.db.profile.units[frame.unitType].healthBar.invert and ShadowUF.db.profile.bars.alpha == 1 ) ) then
+		bar.simple = true
+		bar:SetFrameLevel(frame.topFrameLevel - 2)
+
+		if( bar:GetOrientation() == "HORIZONTAL" ) then
+			bar:SetWidth(frame.healthBar:GetWidth() * cap)
+		else
+			bar:SetHeight(frame.healthBar:GetHeight() * cap)
+		end
+
+		bar:ClearAllPoints()
+
+		local point = bar:GetReverseFill() and "RIGHT" or "LEFT"
+		bar:SetPoint("TOP" .. point, frame.healthBar)
+		bar:SetPoint("BOTTOM" .. point, frame.healthBar)
+	else
+		bar.simple = nil
+		bar:SetFrameLevel(frame.topFrameLevel - 5)
+		bar:SetWidth(1)
+		bar:SetMinMaxValues(0, 1)
+		bar:SetValue(1)
+		bar:ClearAllPoints()
+
+		bar.orientation = bar:GetOrientation()
+		bar.reverseFill = bar:GetReverseFill()
+
+		if( bar.orientation == "HORIZONTAL" ) then
+			bar.healthSize = frame.healthBar:GetWidth()
+			bar.positionPoint = bar.reverseFill and "TOPRIGHT" or "TOPLEFT"
+			bar.positionRelative = bar.reverseFill and "BOTTOMRIGHT" or "BOTTOMLEFT"
+		else
+			bar.healthSize = frame.healthBar:GetHeight()
+			bar.positionPoint = bar.reverseFill and "TOPLEFT" or "BOTTOMLEFT"
+			bar.positionRelative = bar.reverseFill and "TOPRIGHT" or "BOTTOMRIGHT"
+		end
+
+		bar.positionMod = bar.reverseFill and -1 or 1
+		bar.maxSize = bar.healthSize * cap
+	end
+end
+
+function IncHeal:PositionBar(frame, incAmount)
+	local bar = frame.incHeal
+	local health = UnitHealth(frame.unit)
+	local maxHealth = UnitHealthMax(frame.unit)
+
+	if( incAmount <= 0 or UnitIsDeadOrGhost(frame.unit) or maxHealth <= 0 ) then
+		bar.total = nil
+		bar:Hide()
+		return
+	end
+
+	-- TODO: Add option n settings for this value
+	local cap = 1.30
+
+	if( not bar.total ) then bar:Show() end
+	bar.total = incAmount
+
+	-- When the primary bar has an alpha of 100%, we can cheat and do incoming heals easily. Otherwise we need to do it a more complex way to keep it looking good
+	if( bar.simple ) then
+		bar.total = health + incAmount
+		bar:SetMinMaxValues(0, maxHealth * cap)
+		bar:SetValue(bar.total)
+	else
+		local healthSize = bar.healthSize * (health / maxHealth)
+		local incSize = bar.healthSize * (incAmount / maxHealth)
+
+		if( (healthSize + incSize) > bar.maxSize ) then
+			incSize = bar.maxSize - healthSize
+		end
+
+		if incSize <= 0 then
+			bar.total = nil
+			bar:Hide()
+			return
+		end
+
+		if( bar.orientation == "HORIZONTAL" ) then
+			bar:SetWidth(incSize)
+			bar:SetPoint(bar.positionPoint, frame.healthBar, bar.positionMod * healthSize, 0)
+			bar:SetPoint(bar.positionRelative, frame.healthBar, bar.positionMod * healthSize, 0)
+		else
+			bar:SetHeight(incSize)
+			bar:SetPoint(bar.positionPoint, frame.healthBar, 0, bar.positionMod * healthSize)
+			bar:SetPoint(bar.positionRelative, frame.healthBar, 0, bar.positionMod * healthSize)
+		end
+	end
+end
+
+function IncHeal:UpdateFrame(frame)
+	self:PositionBar(frame, 0)
+end

--- a/options/config.lua
+++ b/options/config.lua
@@ -309,7 +309,7 @@ local function hideRestrictedOption(info)
 	local key = info[#(info)]
 	if( ShadowUF.modules[key] and ShadowUF.modules[key].moduleClass and ShadowUF.modules[key].moduleClass ~= playerClass ) then
 		return true
-	elseif( ( key == "incHeal" and not ShadowUF.modules.incHeal ) or ( key == "incAbsorb" and not ShadowUF.modules.incAbsorb ) or ( key == "healAbsorb" and not ShadowUF.modules.healAbsorb ) )  then
+	elseif( key == "incHeal" and not ShadowUF.modules.incHeal )  then
 		return true
 	-- Non-standard units do not support color by aggro or incoming heal
 	elseif( key == "colorDispel" or key == "incHeal" ) then
@@ -1048,7 +1048,7 @@ local function loadGeneralOptions()
 								arg = "healthColors.inc",
 							},
 							enemyUnattack = {
-								order = 11,
+								order = 9,
 								type = "color",
 								name = L["Unattackable hostile"],
 								desc = L["Health bar color to use for hostile units who you cannot attack, used for reaction coloring."],

--- a/options/config.lua
+++ b/options/config.lua
@@ -3345,6 +3345,37 @@ local function loadUnitOptions()
 							}
 						},
 					},
+					incHeal = {
+						order = 3,
+						type = "group",
+						inline = false,
+						name = L["Incoming heals"],
+						hidden = function(info) return ShadowUF.Units.zoneUnits[info[2]] or hideRestrictedOption(info) end,
+						disabled = function(info) return not getVariable(info[2], "healthBar", nil, "enabled") end,
+						args = {
+							heals = {
+								order = 1,
+								type = "toggle",
+								name = L["Show incoming heals"],
+								desc = L["Adds a bar inside the health bar indicating how much healing someone will receive."],
+								arg = "incHeal.enabled",
+								hidden = false,
+								set = function(info, value)
+									setUnit(info, value)
+									setDirectUnit(info[2], "incHeal", nil, "enabled", getVariable(info[2], "incHeal", nil, "enabled"))
+								end
+							},
+							cap = {
+								order = 3,
+								type = "range",
+								name = L["Outside bar limit"],
+								desc = L["Percentage value of how far outside the unit frame the incoming heal bar can go. 130% means it will go 30% outside the frame, 100% means it will not go outside."],
+								min = 1, max = 1.50, step = 0.05, isPercent = true,
+								arg = "incHeal.cap",
+								hidden = false,
+							},
+						},
+					},
 					totemBar = {
 						order = 3.6,
 						type = "group",

--- a/options/config.lua
+++ b/options/config.lua
@@ -312,7 +312,7 @@ local function hideRestrictedOption(info)
 	elseif( ( key == "incHeal" and not ShadowUF.modules.incHeal ) or ( key == "incAbsorb" and not ShadowUF.modules.incAbsorb ) or ( key == "healAbsorb" and not ShadowUF.modules.healAbsorb ) )  then
 		return true
 	-- Non-standard units do not support color by aggro or incoming heal
-	elseif( key == "colorDispel" ) then
+	elseif( key == "colorDispel" or key == "incHeal" ) then
 		return string.match(unit, "%w+target" )
 	-- Fall back for indicators, no variable table so it shouldn't be shown
 	elseif( info[#(info) - 1] == "indicators" ) then
@@ -1039,6 +1039,13 @@ local function loadGeneralOptions()
 								name = L["Static"],
 								desc = L["Color to use for health bars that are set to be colored by a static color."],
 								arg = "healthColors.static",
+							},
+							inc = {
+								order = 8,
+								type = "color",
+								name = L["Incoming heal"],
+								desc = L["Bar color to use to show how much healing someone is about to receive."],
+								arg = "healthColors.inc",
 							},
 							enemyUnattack = {
 								order = 11,


### PR DESCRIPTION
This PR is based on code imported from the master branch of ShadowedUnitFrames, and also
[LunaUnitFrames](https://github.com/Aviana/LunaUnitFrames/blob/master/modules/incheal.lua)

[LibClassicHealComm](https://github.com/Aviana/LibClassicHealComm-1.0) implement incoming heal events behavior for classic that is already used by at least [LunaUnitFrames](https://legacy-wow.com/classic-addons/lunaunitframes/), [HealBot Continued](https://www.curseforge.com/wow/addons/heal-bot-continued), [VuhDo](https://www.curseforge.com/wow/addons/vuhdo).