### PR TITLE
Paladin mana bar module

### DIFF
--- a/ShadowedUnitFrames.lua
+++ b/ShadowedUnitFrames.lua
@@ -5,7 +5,7 @@
 ShadowUF = select(2, ...)
 
 local L = ShadowUF.L
-ShadowUF.dbRevision = 62
+ShadowUF.dbRevision = 63
 ShadowUF.playerUnit = "player"
 ShadowUF.enabledUnits = {}
 ShadowUF.modules = {}
@@ -184,6 +184,7 @@ function ShadowUF:CheckUpgrade()
 		local config = self.db.profile.units
 		config.player.priestBar = {enabled = true, background = true, height = 0.40, order = 70}
 		config.player.shamanBar = {enabled = true, background = true, height = 0.40, order = 70}
+		config.player.paladinBar = {enabled = true, background = true, height = 0.40, order = 70}
 		config.player.arcaneCharges = {enabled = true, anchorTo = "$parent", order = 60, height = 0.40, anchorPoint = "BR", x = -8, y = 6, size = 12, spacing = -2, growth = "LEFT", isBar = true, showAlways = true}
 
 		-- clean out old bars
@@ -352,6 +353,7 @@ function ShadowUF:LoadUnitDefaults()
 	self.defaults.profile.units.player.druidBar = {enabled = false}
 	self.defaults.profile.units.player.priestBar = {enabled = true}
 	self.defaults.profile.units.player.shamanBar = {enabled = true}
+	self.defaults.profile.units.player.paladinBar = {enabled = true}
 	self.defaults.profile.units.player.xpBar = {enabled = false}
 	self.defaults.profile.units.player.fader = {enabled = false}
 	self.defaults.profile.units.player.soulShards = {enabled = true, isBar = true}

--- a/ShadowedUnitFrames.toc
+++ b/ShadowedUnitFrames.toc
@@ -65,6 +65,7 @@ modules\monkstagger.lua
 modules\aurapoints.lua
 modules\priest.lua
 modules\shaman.lua
+modules\paladin.lua
 modules\arcanecharges.lua
 #@do-not-package@
 options\config.lua

--- a/modules/defaultlayout.lua
+++ b/modules/defaultlayout.lua
@@ -347,6 +347,7 @@ function ShadowUF:LoadDefaultLayout(useMerge)
 			druidBar = {enabled = true, background = true, height = 0.40, order = 70},
 			priestBar = {enabled = true, background = true, height = 0.40, order = 70},
 			shamanBar = {enabled = true, background = true, height = 0.40, order = 70},
+			paladinBar = {enabled = true, background = true, height = 0.40, order = 70},
 			comboPoints = {enabled = true, anchorTo = "$parent", order = 60, anchorPoint = "BR", x = -3, y = 8, size = 14, spacing = -4, growth = "LEFT", isBar = true, height = 0.40},
 			auraPoints = {enabled = false, showAlways = true, anchorTo = "$parent", order = 60, anchorPoint = "BR", x = -3, y = 8, size = 14, spacing = -4, growth = "LEFT", isBar = true, height = 0.40},
 			staggerBar = {enabled = true, background = true, height = 0.30, order = 70},

--- a/modules/paladin.lua
+++ b/modules/paladin.lua
@@ -1,0 +1,41 @@
+local Paladin = {}
+ShadowUF:RegisterModule(Paladin, "paladinBar", ShadowUF.L["Paladin mana bar"], true, "PALADIN", {2, SPEC_PALADIN_RETRIBUTION})
+
+function Paladin:OnEnable(frame)
+	frame.paladinBar = frame.paladinBar or ShadowUF.Units:CreateBar(frame)
+	frame:RegisterUnitEvent("UNIT_DISPLAYPOWER", self, "PowerChanged")
+
+	frame:RegisterUpdateFunc(self, "PowerChanged")
+	frame:RegisterUpdateFunc(self, "Update")
+end
+
+function Paladin:OnDisable(frame)
+	frame:UnregisterAll(self)
+end
+
+function Paladin:OnLayoutApplied(frame)
+	if( not frame.visibility.paladinBar ) then return end
+
+	local color = ShadowUF.db.profile.powerColors.MANA
+	frame:SetBarColor("paladinBar", color.r, color.g, color.b)
+end
+
+function Paladin:PowerChanged(frame)
+	local visible = not frame.inVehicle
+	local type = visible and "RegisterUnitEvent" or "UnregisterSingleEvent"
+
+	frame[type](frame, "UNIT_POWER_FREQUENT", self, "Update")
+	frame[type](frame, "UNIT_MAXPOWER", self, "Update")
+	ShadowUF.Layout:SetBarVisibility(frame, "paladinBar", visible)
+
+	if( visible ) then self:Update(frame) end
+end
+
+function Paladin:Update(frame, event, unit, powerType)
+	if( powerType and powerType ~= "MANA" ) then return end
+	frame.paladinBar:SetMinMaxValues(0, UnitPowerMax(frame.unit, Enum.PowerType.Mana))
+	frame.paladinBar:SetValue(UnitIsDeadOrGhost(frame.unit) and 0 or not UnitIsConnected(frame.unit) and 0 or UnitPower(frame.unit, Enum.PowerType.Mana))
+
+	-- disable regular mana bar
+	ShadowUF.Layout:SetBarVisibility(frame, "powerBar", false)
+end

--- a/options/config.lua
+++ b/options/config.lua
@@ -4157,7 +4157,7 @@ local function loadUnitOptions()
 						hidden = function(info)
 							local unit = info[2]
 							if( unit == "global" ) then
-								return not globalConfig.runeBar and not globalConfig.totemBar and not globalConfig.druidBar and not globalConfig.priestBar and not globalConfig.shamanBar and not globalConfig.xpBar and not globalConfig.staggerBar
+								return not globalConfig.runeBar and not globalConfig.totemBar and not globalConfig.druidBar and not globalConfig.priestBar and not globalConfig.shamanBar and not globalConfig.paladinBar and not globalConfig.xpBar and not globalConfig.staggerBar
 							else
 								return unit ~= "player" and unit ~= "pet"
 							end
@@ -4199,9 +4199,17 @@ local function loadUnitOptions()
 								order = 3,
 								type = "toggle",
 								name = string.format(L["Enable %s"], L["Shaman mana bar"]),
-								desc = L["Adds a mana bar to the player frame for elemental and enhancement shamans."],
+								desc = L["Adds a mana bar to the player frame for elemental and enhancement shaman."],
 								hidden = hideRestrictedOption,
 								arg = "shamanBar.enabled",
+							},
+							paladinBar = {
+								order = 3,
+								type = "toggle",
+								name = string.format(L["Enable %s"], L["Paladin mana bar"]),
+								desc = L["Adds a mana bar to the player frame for retribution and protection paladins."],
+								hidden = hideRestrictedOption,
+								arg = "paladinBar.enabled",
 							},
 							xpBar = {
 								order = 4,


### PR DESCRIPTION
Adds an option to enable a "Paladin mana bar" which can be sized independently of the regular power bar. Mana for Prot/Ret Paladins functions much more similarly to mana for Shadow Priests or Enhance/Elemental Shaman, despite being considered a primary power instead of Holy Power.

With "Paladin mana bar" enabled the original mana power bar will be hidden for Prot/Ret, in effect treating Holy Power as the primary resource.