### PR TITLE
combopoints: Fix combo points on target frame

### DIFF
--- a/modules/basecombopoints.lua
+++ b/modules/basecombopoints.lua
@@ -176,7 +176,7 @@ function Combo:Update(frame, event, unit, powerType)
 	-- Anything power based will have an eventType to filter on
 	if( event and frame[key].cpConfig.eventType and frame[key].cpConfig.eventType ~= powerType ) then return end
 
-	local points = self:GetPoints(unit)
+	local points = self:GetPoints(unit, frame)
 
 	-- Bar display, hide it if we don't have any combo points
 	if( ShadowUF.db.profile.units[frame.unitType][key].isBar ) then

--- a/modules/combopoints.lua
+++ b/modules/combopoints.lua
@@ -10,6 +10,7 @@ function Combo:OnEnable(frame)
 
 	frame:RegisterNormalEvent("UNIT_POWER_UPDATE", self, "Update", "player")
 	frame:RegisterNormalEvent("UNIT_POWER_FREQUENT", self, "Update", "player")
+	frame:RegisterNormalEvent("PLAYER_TARGET_CHANGED", self, "Update", "player")
 	frame:RegisterNormalEvent("UNIT_MAXPOWER", self, "UpdateBarBlocks", "player")
 
 	frame:RegisterUpdateFunc(self, "Update")
@@ -29,12 +30,19 @@ function Combo:GetMaxPoints()
 	end
 end
 
-function Combo:GetPoints(unit)
-	return UnitPower("player", cpConfig.powerType)
+function Combo:GetPoints(unit, frame)
+	if frame.unit == "target" then
+		return GetComboPoints("player", "target")
+	else
+		return UnitPower("player", cpConfig.powerType)
+	end
 end
 
 function Combo:Update(frame, event, unit, powerType)
 	if( not event or ( unit == frame.unit or unit == "player" ) ) then
 		ShadowUF.ComboPoints.Update(self, frame, event, unit, powerType)
+	elseif(event == "PLAYER_TARGET_CHANGED" and frame.unit == "target") then
+		ShadowUF.ComboPoints.Update(self, frame, event, "player", cpConfig.powerType)
 	end
+
 end


### PR DESCRIPTION
The existing code in tbc classic doesn't account for the fact
that rogue combo points only apply to a particular target. Therefore
if a user decides to show combo points on their target frame, the
player will have odd display when switching between targets.
This patch prevents incorrect combo point count on target frame.