### PR TITLE
Party NPC class colours

### DIFF
--- a/modules/health.lua
+++ b/modules/health.lua
@@ -115,6 +115,9 @@ function Health:UpdateColor(frame)
 				color = ShadowUF.db.profile.healthColors.hostile
 			end
 		end
+	elseif( ShadowUF.db.profile.units[frame.unitType].healthBar.colorType == "class" and (UnitPlayerOrPetInParty(unit) or unit == "pet") ) then
+		local class = (unit == "pet") and "PET" or frame:UnitClassToken()
+		color = class and ShadowUF.db.profile.classColors[class]
 	elseif( ShadowUF.db.profile.units[frame.unitType].healthBar.colorType == "class" and (UnitIsPlayer(unit) or unit == "pet") ) then
 		local class = (unit == "pet") and "PET" or frame:UnitClassToken()
 		color = class and ShadowUF.db.profile.classColors[class]


### PR DESCRIPTION
Added check to apply class colours to NPCs in party (useful for Mage Tower etc.)

It checks if the unit is in a party with the player, and if so applies class colours, general syntax for the check copied from the other checks below it. Shouldn't have any weird interaction as the check can only pass on party members. Tested in game with no issues.