### PR TITLE
fix(indicators): only SetAlpha when 0

### DIFF
--- a/modules/indicators.lua
+++ b/modules/indicators.lua
@@ -273,7 +273,10 @@ function Indicators:UpdateReadyCheck(frame, event)
 					hasTimer = true
 
 					f.fadeList[fadeFrame] = timeLeft - elapsed
-					fadeFrame:SetAlpha(f.fadeList[fadeFrame] / FADEOUT_TIME)
+					local fadeFrameAlpha = f.fadeList[fadeFrame] / FADEOUT_TIME
+					if ( fadeFrameAlpha >= 0 ) then
+						fadeFrame:SetAlpha(fadeFrameAlpha)
+					end
 
 					if( f.fadeList[fadeFrame] <= 0 ) then
 						f.fadeList[fadeFrame] = nil

--- a/modules/indicators.lua
+++ b/modules/indicators.lua
@@ -274,7 +274,7 @@ function Indicators:UpdateReadyCheck(frame, event)
 
 					f.fadeList[fadeFrame] = timeLeft - elapsed
 					local fadeFrameAlpha = f.fadeList[fadeFrame] / FADEOUT_TIME
-					if ( fadeFrameAlpha >= 0 ) then
+					if ( fadeFrameAlpha > 0 ) then
 						fadeFrame:SetAlpha(fadeFrameAlpha)
 					end
 


### PR DESCRIPTION
I'm not sure on root cause but this fixes this from constantly spewing errors:

```
119883x ...ace/AddOns/ShadowedUnitFrames/modules/indicators.lua:276: bad argument #1 to 'SetAlpha' (Usage: self:SetAlpha(alpha))
[string "=[C]"]: in function `SetAlpha'
[string "@Interface/AddOns/ShadowedUnitFrames/modules/indicators.lua"]:276: in function <...ace/AddOns/ShadowedUnitFrames/modules/indicators.lua:270>

Locals:
(*temporary) = Texture {
enabled = true
status = "ready"
0 = <userdata>
}
(*temporary) = -0.001000
```

Basically at some point everything goes haywire and it keeps trying to set this value to a negative number. This seems to resolve it for me