### PR TITLE
Add groupBy option also available to party

### DIFF
--- a/modules/units.lua
+++ b/modules/units.lua
@@ -914,6 +914,17 @@ function Units:SetHeaderAttributes(frame, type)
 		frame:SetAttribute("columnSpacing", config.columnSpacing)
 		frame:SetAttribute("columnAnchorPoint", config.attribAnchorPoint)
 
+		if( config.groupBy == "CLASS" ) then
+			frame:SetAttribute("groupingOrder", "DEATHKNIGHT,DEMONHUNTER,DRUID,HUNTER,MAGE,PALADIN,PRIEST,ROGUE,SHAMAN,WARLOCK,WARRIOR,MONK")
+			frame:SetAttribute("groupBy", "CLASS")
+		elseif( config.groupBy == "ASSIGNEDROLE" ) then
+			frame:SetAttribute("groupingOrder", "TANK,HEALER,DAMAGER,NONE")
+			frame:SetAttribute("groupBy", "ASSIGNEDROLE")
+		else
+			frame:SetAttribute("groupingOrder", "1,2,3,4,5,6,7,8")
+			frame:SetAttribute("groupBy", "GROUP")
+		end
+
 		self:CheckGroupVisibility()
 		if( stateMonitor.party ) then
 			stateMonitor.party:SetAttribute("hideSemiRaid", ShadowUF.db.profile.units.party.hideSemiRaid)

--- a/options/config.lua
+++ b/options/config.lua
@@ -1663,12 +1663,20 @@ local function loadUnitOptions()
 		return info[2] ~= "raid" and info[2] ~= "raidpet" and info[2] ~= "maintank" and info[2] ~= "mainassist"
 	end
 
+	local function hideRaidOrPartyOption(info)
+		return hideRaidOption(info) and info[2] ~= "party"
+	end
+
 	local function hideSplitOrRaidOption(info)
 		if( info[2] == "raid" and ShadowUF.db.profile.units.raid.frameSplit ) then
 			return true
 		end
 
 		return hideRaidOption(info)
+	end
+
+	local function hideSplitOrRaidOrPartyOption(info)
+		return hideSplitOrRaidOption(info) and info[2] ~= "party"
 	end
 
 	-- Not every option should be changed via global settings
@@ -3898,12 +3906,12 @@ local function loadUnitOptions()
 							},
 						},
 					},
-					raid = {
+					groups = {
 						order = 3,
 						type = "group",
 						inline = true,
 						name = L["Groups"],
-						hidden = hideRaidOption,
+						hidden = hideRaidOrPartyOption,
 						args = {
 							groupBy = {
 								order = 4,
@@ -3911,7 +3919,7 @@ local function loadUnitOptions()
 								name = L["Group by"],
 								values = {["GROUP"] = L["Group number"], ["CLASS"] = L["Class"], ["ASSIGNEDROLE"] = L["Assigned Role (DPS/Tank/etc)"]},
 								arg = "groupBy",
-								hidden = hideSplitOrRaidOption,
+								hidden = hideSplitOrRaidOrPartyOption,
 							},
 							selectedGroups = {
 								order = 7,


### PR DESCRIPTION
The groupBy option was missing for party and I was used to having my party sort by assigned role with the Blizzard interface.