### PR TITLE
Fix hiding of arena frames

### DIFF
--- a/ShadowedUnitFrames.lua
+++ b/ShadowedUnitFrames.lua
@@ -800,13 +800,14 @@ function ShadowUF:HideBlizzardFrames()
 		end
 	end
 
-	if( self.db.profile.hidden.arena and not active_hiddens.arenaTriggered and IsAddOnLoaded("Blizzard_ArenaUI") and not InCombatLockdown() ) then
+	if( self.db.profile.hidden.arena and not active_hiddens.arenaTriggered ) then
 		active_hiddens.arenaTriggered = true
 
-		ArenaEnemyFrames:UnregisterAllEvents()
-		ArenaEnemyFrames:SetParent(self.hiddenFrame)
-		ArenaPrepFrames:UnregisterAllEvents()
-		ArenaPrepFrames:SetParent(self.hiddenFrame)
+		if( _G.ArenaEnemyFramesContainer ) then
+			hideBlizzardFrames(true, ArenaEnemyFramesContainer, ArenaEnemyPrepFramesContainer, ArenaEnemyMatchFramesContainer)
+		else
+			basicHideBlizzardFrames(ArenaEnemaFrames, ArenaEnemyPrep)
+		end
 	end
 
 	if( self.db.profile.hidden.playerAltPower and not active_hiddens.playerAltPower ) then


### PR DESCRIPTION
Fixes multiple problems with hiding arena frames:
  - No longer check for "Blizzard_ArenaUI" which isn't loaded in Retail.
  - Remove InCombatLockdown check that seems unnecessary at init time.
  - Check for `ArenaEnemyFramesContainer` to detect if Retail.
  - Make sure loading frames is also a noop for Retail.
  - For non-retail just hide the 2 frames and unregister events.