### PR TITLE
Check that power frames exist before hiding.

### DIFF
--- a/ShadowedUnitFrames.lua
+++ b/ShadowedUnitFrames.lua
@@ -774,7 +774,12 @@ function ShadowUF:HideBlizzardFrames()
 	end
 
 	if( self.db.profile.hidden.playerPower and not active_hiddens.playerPower ) then
-		basicHideBlizzardFrames(PriestBarFrame, RuneFrame, WarlockPowerFrame, MonkHarmonyBarFrame, PaladinPowerBarFrame, MageArcaneChargesFrame)
+		local powerBarFrames = {"PriestBarFrame", "RuneFrame", "WarlockPowerFrame", "MonkHarmonyBarFrame", "PaladinPowerBarFrame", "MageArcaneChargesFrame"}
+		for _, frame in pairs(powerBarFrames) do
+			if _G[frame] then
+				basicHideBlizzardFrames(_G[frame])
+			end
+		end
 	end
 
 	if( self.db.profile.hidden.pet and not active_hiddens.pet ) then


### PR DESCRIPTION
On the PTR choosing to disable power bars throws LUA errors as soon as it encounters a bar that isn't for your current class. This solves that bug by first checking if the power bars exist before trying to hide them.

Note: I've only tested it with my Warlock and it does hide the soul shard bar.