### PR TITLE
10.1.5 fix for Ready Check not showing

### DIFF
--- a/modules/indicators.lua
+++ b/modules/indicators.lua
@@ -293,11 +293,11 @@ function Indicators:UpdateReadyCheck(frame, event)
 	end
 
 	if( status == "ready" ) then
-		frame.indicators.ready:SetTexture(READY_CHECK_READY_TEXTURE)
+		frame.indicators.ready:SetTexture("Interface\\RaidFrame\\ReadyCheck-Ready")
 	elseif( status == "notready" ) then
-		frame.indicators.ready:SetTexture(READY_CHECK_NOT_READY_TEXTURE)
+		frame.indicators.ready:SetTexture("Interface\\RaidFrame\\ReadyCheck-NotReady")
 	elseif( status == "waiting" ) then
-		frame.indicators.ready:SetTexture(READY_CHECK_WAITING_TEXTURE)
+		frame.indicators.ready:SetTexture("Interface\\RaidFrame\\ReadyCheck-Waiting")
 	end
 
 	frame.indicators:SetScript("OnUpdate", nil)


### PR DESCRIPTION
This might not have been an issue before 10.1.5, or was going to be a new change, but it currently doesn't show ready checks when done. This will at least bring back the function