### PR TITLE
Update STAGGER_STATES global for 10.2

### DIFF
--- a/modules/monkstagger.lua
+++ b/modules/monkstagger.lua
@@ -41,9 +41,9 @@ function Stagger:Update(frame)
 	-- Figure out how screwed they are
 	local percent = stagger / frame.staggerBar.maxHealth
 	local state
-	if( percent < STAGGER_YELLOW_TRANSITION ) then
+	if( percent < STAGGER_STATES.YELLOW.threshold ) then
 		state = "STAGGER_GREEN"
-	elseif( percent < STAGGER_RED_TRANSITION ) then
+	elseif( percent < STAGGER_STATES.RED.threshold ) then
 		state = "STAGGER_YELLOW"
 	else
 		state = "STAGGER_RED"


### PR DESCRIPTION
10.2 added a new table-type global `STAGGER_STATES` to replace the old decimal variables like `STAGGER_RED_TRANSITION`. These are now undefined (causing lua errors + stagger bar color doesn't work). This commit updates SUF to get stagger thresholds in the [same way official UI code does](https://github.com/Gethe/wow-ui-source/blob/d4aa41ee5366c48fa8a04b9263afec45415c34d2/Interface/FrameXML/MonkStaggerBar.lua#L35).