### PR TITLE
 Class Portrait update

### DIFF
--- a/modules/portrait.lua
+++ b/modules/portrait.lua
@@ -65,8 +65,12 @@ function Portrait:Update(frame, event)
 	if( type == "class" ) then
 		local classToken = frame:UnitClassToken()
 		if( classToken ) then
-			frame.portrait:SetTexture("Interface\\Glues\\CharacterCreate\\UI-CharacterCreate-Classes")
-			frame.portrait:SetTexCoord(CLASS_ICON_TCOORDS[classToken][1], CLASS_ICON_TCOORDS[classToken][2], CLASS_ICON_TCOORDS[classToken][3], CLASS_ICON_TCOORDS[classToken][4])
+			local classIconAtlas = GetClassAtlas(classToken)
+			if( classIconAtlas ) then
+				frame.portrait:SetAtlas(classIconAtlas)
+			else
+				frame.portrait:SetTexture("")
+			end
 		else
 			frame.portrait:SetTexture("")
 		end


### PR DESCRIPTION
Hi.
Class icon portraits are looking very dated. The game already has a better, high res version, so changed them using the GetClassAtlas method.
( Filename which contains these in the game: "interface/glues/charactercreate/charactercreateicons.blp" )
Preview:
left is current, right is new
![class_portrait](https://github.com/Nevcairiel/ShadowedUnitFrames/assets/272450/669158cc-9c0b-43bb-a3a8-b1521f95aa28)
