### PR TITLE
Fix lua error mount/unmount vehicle

### DIFF
--- a/modules/combopoints.lua
+++ b/modules/combopoints.lua
@@ -24,7 +24,7 @@ end
 function Combo:GetPoints(unit)
 	-- For Malygos dragons, they also self cast their CP on themselves, which is why we check CP on ourself
 	if( UnitHasVehicleUI("player") and UnitHasVehiclePlayerFrameUI("player") ) then
-		local points = GetComboPoints("vehicle")
+		local points = GetComboPoints("vehicle", "target")
 		if( points == 0 ) then
 			points = GetComboPoints("vehicle", "vehicle")
 		end


### PR DESCRIPTION
Fix for this lua error:

```lua
141x ...ceShadowedUnitFrames/modules/combopoints.lua:27: Usage: local result = GetComboPoints(unit, target)
[string "=[C]"]: in function `GetComboPoints'
[string "@ShadowedUnitFrames/modules/combopoints.lua"]:27: in function `GetPoints'
[string "@ShadowedUnitFrames/modules/basecombopoints.lua"]:180: in function `Update'
[string "@ShadowedUnitFrames/modules/combopoints.lua"]:40: in function `?'
[string "@ShadowedUnitFrames/modules/units.lua"]:36: in function `FullUpdate'
[string "@ShadowedUnitFrames/modules/units.lua"]:1556: in function <ShadowedUnitFrames/modules/units.lua:1520>

Locals:
(*temporary) = "vehicle"
```