### PR TITLE
Fix curable debuffs in `health.lua` and `highlight.lua`

### DIFF
--- a/modules/health.lua
+++ b/modules/health.lua
@@ -62,8 +62,10 @@ function Health:UpdateAura(frame)
 		local id = 0
 		while( true ) do
 			id = id + 1
-			local name, _, _, auraType = UnitDebuff(frame.unit, id)
-			if( not name ) then break end
+			local info = C_UnitAuras.GetDebuffDataByIndex(frame.unit, id)
+
+			if( not info ) then break end
+			local auraType = info["dispelName"]
 
 			if( canCure[auraType] ) then
 				frame.healthBar.hasDebuff = auraType

--- a/modules/highlight.lua
+++ b/modules/highlight.lua
@@ -179,8 +179,10 @@ function Highlight:UpdateAura(frame)
 		local id = 0
 		while( true ) do
 			id = id + 1
-			local name, _, _, auraType = UnitDebuff(frame.unit, id)
-			if( not name ) then break end
+			local info = C_UnitAuras.GetDebuffDataByIndex(frame.unit, id)
+
+			if( not info ) then break end
+			local auraType = info["dispelName"]
 			if( auraType == "" ) then auraType = "Enrage" end
 
 			if( canCure[auraType] ) then


### PR DESCRIPTION
Updated health coloring and frame highlighting to use new `C_UnitAuras.GetDebuffDataByIndex` API. Old `UnitDebuff` no longer returns dispel type