### PR TITLE
fix deprecated function UnitDebuff

### DIFF
--- a/modules/health.lua
+++ b/modules/health.lua
@@ -62,8 +62,10 @@ function Health:UpdateAura(frame)
 		local id = 0
 		while( true ) do
 			id = id + 1
-			local name, _, _, auraType = UnitDebuff(frame.unit, id)
-			if( not name ) then break end
+			local auraData = C_UnitAuras.GetAuraDataByIndex(frame.unit, id, "HARMFUL")
+			if not auraData then break end
+			local name = auraData.name
+			local auraType = auraData.dispelName
 
 			if( canCure[auraType] ) then
 				frame.healthBar.hasDebuff = auraType

--- a/modules/highlight.lua
+++ b/modules/highlight.lua
@@ -179,7 +179,7 @@ function Highlight:UpdateAura(frame)
 		local id = 0
 		while( true ) do
 			id = id + 1
-			local name, _, _, auraType = UnitDebuff(frame.unit, id)
+			local name, _, _, auraType = C_UnitAuras.GetDebuffDataByIndex(frame.unit, id)
 			if( not name ) then break end
 			if( auraType == "" ) then auraType = "Enrage" end
 

--- a/modules/highlight.lua
+++ b/modules/highlight.lua
@@ -179,7 +179,10 @@ function Highlight:UpdateAura(frame)
 		local id = 0
 		while( true ) do
 			id = id + 1
-			local name, _, _, auraType = C_UnitAuras.GetDebuffDataByIndex(frame.unit, id)
+			local auraData = C_UnitAuras.GetAuraDataByIndex(frame.unit, id, "HARMFUL")
+			if not auraData then break end
+			local name = auraData.name
+			local auraType = auraData.dispelName
 			if( not name ) then break end
 			if( auraType == "" ) then auraType = "Enrage" end
 


### PR DESCRIPTION
replace deprecated function UnitDebuff with C_UnitAuras.GetAuraByIndex in health and highlight modules. These function deprecations cause other functionality to break.