### PR TITLE
Fix: Hide BossTargetFrameContainer to prevent related erorr

### DIFF
--- a/ShadowedUnitFrames.lua
+++ b/ShadowedUnitFrames.lua
@@ -801,6 +801,8 @@ function ShadowUF:HideBlizzardFrames()
 	end
 
 	if( self.db.profile.hidden.boss and not active_hiddens.boss ) then
+		hideBlizzardFrames(false, BossTargetFrameContainer)
+
 		for i=1, MAX_BOSS_FRAMES do
 			local name = "Boss" .. i .. "TargetFrame"
 			if _G[name].TargetFrameContent then


### PR DESCRIPTION
# Description

## The Issue
When "Hide boss frames" option is turned on in SUF, the snap-to-grid feature doesn't work in Blizzard Edit Mode.

Reported on Wowace:
- as steps to reproduce - https://www.wowace.com/projects/shadowed-unit-frames/issues/2118
- as the error dump - https://www.wowace.com/projects/shadowed-unit-frames/issues/1932

## The fix
Calling `hideBlizzardFrames` on `BossTargetFrameContainer` seems to fix the problem.
Assumption - a specific event that is causing the issue is unregistered and not being called at all.

## Appendix
Error dump
```lua
47x ...izzard_EditMode/Mainline/EditModeSystemTemplates.lua:535: attempt to perform arithmetic on local 'left' (a nil value)
[string "@Blizzard_EditMode/Mainline/EditModeSystemTemplates.lua"]:535: in function `GetScaledSelectionSides'
[string "@Blizzard_EditMode/Mainline/EditModeSystemTemplates.lua"]:507: in function `IsVerticallyAlignedWithFrame'
[string "@Blizzard_EditMode/Mainline/EditModeSystemTemplates.lua"]:725: in function `GetFrameMagneticEligibility'
[string "@Blizzard_EditMode/Mainline/EditModeUtil.lua"]:152: in function `GetEligibleMagneticFrames'
[string "@Blizzard_EditMode/Mainline/EditModeUtil.lua"]:341: in function `GetMagneticFrameInfoOptions'
[string "@Blizzard_EditMode/Mainline/EditModeUtil.lua"]:424: in function `GetMagneticFrameInfos'
[string "@Blizzard_EditMode/Mainline/EditModeManager.lua"]:961: in function `RefreshSnapPreviewLines'
[string "@Blizzard_EditMode/Mainline/EditModeManager.lua"]:72: in function <...ddOns/Blizzard_EditMode/Mainline/EditModeManager.lua:70>

Locals:
self = BossTargetFrameContainer {
 systemInfo = <table> {
 }
 downKeys = <table> {
 }
 breakSnappedFramesOnSave = true
 smallSize = true
 spacing = 10
 alwaysUseTopRightAnchor = true
 isManagedFrame = true
 hasActiveChanges = false
 dirty = false
 isHighlighted = true
 systemIndex = 6
 isInEditMode = true
 snappedFrames = <table> {
 }
 ignoreFramePositionManager = true
 isRightManagedFrame = true
 layoutParent = UIParentRightManagedFrameContainer {
 }
 savedSystemInfo = <table> {
 }
 systemNameString = "Рамки боссов"
 BossTargetFrames = <table> {
 }
 isSelected = false
 castBarOnSide = true
 dirtySettings = <table> {
 }
 hideWhenActionBarIsOverriden = false
 settingMap = <table> {
 }
 settingDisplayInfoMap = <table> {
 }
 Selection = Frame {
 }
 settingsDialogAnchor = <table> {
 }
 align = "right"
 respectChildScale = true
 layoutIndex = 4
 defaultHideSelection = true
 system = 3
 rightPadding = -70
}
left = nil
bottom = nil
width = nil
height = nil
scale = 1
(*temporary) = BossTargetFrameContainer {
 systemInfo = <table> {
 }
 downKeys = <table> {
 }
 breakSnappedFramesOnSave = true
 smallSize = true
 spacing = 10
 alwaysUseTopRightAnchor = true
 isManagedFrame = true
 hasActiveChanges = false
 dirty = false
 isHighlighted = true
 systemIndex = 6
 isInEditMode = true
 snappedFrames = <table> {
 }
 ignoreFramePositionManager = true
 isRightManagedFrame = true
 layoutParent = UIParentRightManagedFrameContainer {
 }
 savedSystemInfo = <table> {
 }
 systemNameString = "Рамки боссов"
 BossTargetFrames = <table> {
 }
 isSelected = false
 castBarOnSide = true
 dirtySettings = <table> {
 }
 hideWhenActionBarIsOverriden = false
 settingMap = <table> {
 }
 settingDisplayInfoMap = <table> {
 }
 Selection = Frame {
 }
 settingsDialogAnchor = <table> {
 }
 align = "right"
 respectChildScale = true
 layoutIndex = 4
 defaultHideSelection = true
 system = 3
 rightPadding = -70
}
(*temporary) = 1
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to perform arithmetic on local 'left' (a nil value)"
```