### PR TITLE
Fix power display for units out of range on era.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,17 @@
+# Intro
+This is a downstream repository from Nevcairiel/ShadowedUnitFrames, intended to provide fixes and features that the upstream repo cannot or will not provide. See the .patch files in patches/ for a list of features and bug fixes.
+
+# How to use
+To use this downstream distribution of ShadowedUnitFrames, run the following commands:
+```
+git clone https://github.com/bjthompson805/ShadowedUnitFrames
+cd ShadowedUnitFrames
+make setup
+make update
+```
+Then, copy the folder into your WoW addons folder.
+
+This will fetch the upstream repo and then apply the patches from this repo on top, one by one. If any patch fails to be applied due to recent upstream changes, it will notify you, but because of the way patches are (or should be) implemented, this will not break the addon, and the feature/bug-fix that the patch provides will simply not be there.
+
+This patching method is much better than 'git rebase' (which tries to add commits on top of upstream's commits) because any failure would completely break the build and make it unusable.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+UPSTREAM := https://github.com/Nevcairiel/ShadowedUnitFrames.git
+UPSTREAM_BRANCH := classic
+
+.PHONY: setup update regen-patches
+
+setup:
+	git remote add upstream $(UPSTREAM) || true
+	git fetch upstream $(UPSTREAM_BRANCH)
+
+update:
+	git fetch upstream $(UPSTREAM_BRANCH)
+	git rebase upstream/$(UPSTREAM_BRANCH)
+	git am patches/*.patch
+
+regen-patches:
+	git format-patch upstream/$(UPSTREAM_BRANCH) -o patches/ --no-stat

--- a/patches/0001-Fix-power-display-for-units-out-of-range-on-era.patch
+++ b/patches/0001-Fix-power-display-for-units-out-of-range-on-era.patch
@@ -1,0 +1,113 @@
+From 34cacf94088be4978b96eb0d1dff38e8dd86d813 Mon Sep 17 00:00:00 2001
+From: Brandon Thompson <bthompson@BOOK-1FP7SF02V3.>
+Date: Sat, 15 Mar 2025 00:33:14 -0700
+Subject: [PATCH] Fix power display for units out of range on era.
+
+
+diff --git a/modules/power.lua b/modules/power.lua
+index 74e9339..4cb037d 100755
+--- a/modules/power.lua
++++ b/modules/power.lua
+@@ -96,7 +96,8 @@ function Power:Update(frame, event, unit, powerType)
+ 	if( event and powerType and powerType ~= frame.powerBar.currentType ) then return end
+ 	if( frame.powerBar.minusMob ) then return end
+ 
++	local powerType = UnitPowerType(frame.unit)
+ 	frame.powerBar.currentPower = UnitPower(frame.unit)
+-	frame.powerBar:SetMinMaxValues(0, UnitPowerMax(frame.unit))
++	frame.powerBar:SetMinMaxValues(0, UnitPowerMax(frame.unit, powerType))
+ 	frame.powerBar:SetValue(UnitIsDeadOrGhost(frame.unit) and 0 or not UnitIsConnected(frame.unit) and 0 or frame.powerBar.currentPower)
+ end
+diff --git a/modules/tags.lua b/modules/tags.lua
+index 1a84598..bf1f1ba 100755
+--- a/modules/tags.lua
++++ b/modules/tags.lua
+@@ -590,7 +590,8 @@ Tags.defaultTags = {
+ 		return string.format("%s%s|r", color, name)
+ 	end]],
+ 	["curpp"] = [[function(unit, unitOwner)
+-		if( UnitPowerMax(unit) <= 0 ) then
++		local powerType = UnitPowerType(unit)
++		if( UnitPowerMax(unit, powerType) <= 0 ) then
+ 			return nil
+ 		elseif( UnitIsDeadOrGhost(unit) ) then
+ 			return 0
+@@ -644,7 +645,8 @@ Tags.defaultTags = {
+ 	end]],
+ 	["absmaxhp"] = [[function(unit, unitOwner) return UnitHealthMax(unit) end]],
+ 	["abscurpp"] = [[function(unit, unitOwner)
+-		if( UnitPowerMax(unit) <= 0 ) then
++		local powerType = UnitPowerType(unit)
++		if( UnitPowerMax(unit, powerType) <= 0 ) then
+ 			return nil
+ 		elseif( UnitIsDeadOrGhost(unit) ) then
+ 			return 0
+@@ -653,11 +655,13 @@ Tags.defaultTags = {
+ 		return UnitPower(unit)
+ 	end]],
+ 	["absmaxpp"] = [[function(unit, unitOwner)
+-		local power = UnitPowerMax(unit)
++		local powerType = UnitPowerType(unit)
++		local power = UnitPowerMax(unit, powerType)
+ 		return power > 0 and power or nil
+ 	end]],
+ 	["absolutepp"] = [[function(unit, unitOwner)
+-		local maxPower = UnitPowerMax(unit)
++		local powerType = UnitPowerType(unit)
++		local maxPower = UnitPowerMax(unit, powerType)
+ 		local power = UnitPower(unit)
+ 		if( UnitIsDeadOrGhost(unit) ) then
+ 			return string.format("0/%s", maxPower)
+@@ -668,7 +672,8 @@ Tags.defaultTags = {
+ 		return string.format("%s/%s", power, maxPower)
+ 	end]],
+ 	["curmaxpp"] = [[function(unit, unitOwner)
+-		local maxPower = UnitPowerMax(unit)
++		local powerType = UnitPowerType(unit)
++		local maxPower = UnitPowerMax(unit, powerType)
+ 		local power = UnitPower(unit)
+ 		if( UnitIsDeadOrGhost(unit) ) then
+ 			return string.format("0/%s", ShadowUF:FormatLargeNumber(maxPower))
+@@ -679,7 +684,8 @@ Tags.defaultTags = {
+ 		return string.format("%s/%s", ShadowUF:FormatLargeNumber(power), ShadowUF:FormatLargeNumber(maxPower))
+ 	end]],
+ 	["smart:curmaxpp"] = [[function(unit, unitOwner)
+-		local maxPower = UnitPowerMax(unit)
++		local powerType = UnitPowerType(unit)
++		local maxPower = UnitPowerMax(unit, powerType)
+ 		local power = UnitPower(unit)
+ 		if( UnitIsDeadOrGhost(unit) ) then
+ 			return string.format("0/%s", maxPower)
+@@ -713,7 +719,8 @@ Tags.defaultTags = {
+ 	end]],
+ 	["maxhp"] = [[function(unit, unitOwner) return ShadowUF:FormatLargeNumber(UnitHealthMax(unit)) end]],
+ 	["maxpp"] = [[function(unit, unitOwner)
+-		local power = UnitPowerMax(unit)
++		local powerType = UnitPowerType(unit)
++		local power = UnitPowerMax(unit, powerType)
+ 		if( power <= 0 ) then
+ 			return nil
+ 		elseif( UnitIsDeadOrGhost(unit) ) then
+@@ -736,7 +743,8 @@ Tags.defaultTags = {
+ 		return "-" .. ShadowUF:FormatLargeNumber(missing)
+ 	end]],
+ 	["missingpp"] = [[function(unit, unitOwner)
+-		local power = UnitPowerMax(unit)
++		local powerType = UnitPowerType(unit)
++		local power = UnitPowerMax(unit, powerType)
+ 		if( power <= 0 ) then
+ 			return nil
+ 		end
+@@ -769,7 +777,8 @@ Tags.defaultTags = {
+ 		return math.floor(UnitHealth(unit) / max * 100 + 0.5) .. "%"
+ 	end]],
+ 	["perpp"] = [[function(unit, unitOwner)
+-		local maxPower = UnitPowerMax(unit)
++		local powerType = UnitPowerType(unit)
++		local maxPower = UnitPowerMax(unit, powerType)
+ 		if( maxPower <= 0 ) then
+ 			return nil
+ 		elseif( UnitIsDeadOrGhost(unit) or not UnitIsConnected(unit) ) then
+-- 
+2.54.0
+


### PR DESCRIPTION
This fixes an issue on era where any units that are far away or in another zone will not show power at all. This should also work on Cata.