### PR TITLE
fix: CheckInteractDistance protected call error

### DIFF
--- a/modules/range.lua
+++ b/modules/range.lua
@@ -50,7 +50,8 @@ local function checkRange(self)
 		frame:SetRangeAlpha(UnitInRange(frame.unit, "player") and ShadowUF.db.profile.units[frame.unitType].range.inAlpha or ShadowUF.db.profile.units[frame.unitType].range.oorAlpha)
 	-- Nope, fall back to interaction :(
 	else
-		frame:SetRangeAlpha(CheckInteractDistance(frame.unit, 4) and ShadowUF.db.profile.units[frame.unitType].range.inAlpha or ShadowUF.db.profile.units[frame.unitType].range.oorAlpha)
+		local inRange = InCombatLockdown() or CheckInteractDistance(frame.unit, 4)
+		frame:SetRangeAlpha(inRange and ShadowUF.db.profile.units[frame.unitType].range.inAlpha or ShadowUF.db.profile.units[frame.unitType].range.oorAlpha)
 	end
 end
 


### PR DESCRIPTION
Fix this lua error popping up in combat:
[ADDON_ACTION_BLOCKED] AddOn 'ShadowedUnitFrames' tried to call the protected function 'CheckInteractDistance()'.
[string "@!BugGrabber/BugGrabber.lua"]:485: in function <!BugGrabber/BugGrabber.lua:485>
[string "=[C]"]: in function `CheckInteractDistance'
[string "@ShadowedUnitFrames/modules/range.lua"]:53: in function <ShadowedUnitFrames/modules/range.lua:33>
[string "@ShadowedUnitFrames/modules/range.lua"]:100: in function `?'
[string "@ShadowedUnitFrames/modules/units.lua"]:21: in function `FullUpdate'
[string "@ShadowedUnitFrames/modules/units.lua"]:295: in function `CheckUnitStatus'
[string "@ShadowedUnitFrames/modules/units.lua"]:211: in function <ShadowedUnitFrames/modules/units.lua:208>
[string "=[C]"]: in function `Show'
[string "@FrameXML/SecureStateDriver.lua"]:83: in function <FrameXML/SecureStateDriver.lua:73>
[string "@FrameXML/SecureStateDriver.lua"]:137: in function <FrameXML/SecureStateDriver.lua:119>