### PR TITLE
MoP Classic 5.5.4 (68016) compatibility fixes

### DIFF
--- a/ShadowedUnitFrames.lua
+++ b/ShadowedUnitFrames.lua
@@ -4,6 +4,21 @@
 
 ShadowUF = select(2, ...)
 
+-- MoP 5.5.4 compat: DebuffTypeColor was replaced by individual globals
+-- (DEBUFF_TYPE_MAGIC_COLOR etc.). Rebuild the table from those if present,
+-- falling back to the classic WoW defaults so debuff border colours remain
+-- correct without hardcoding values that could differ per locale/patch.
+if not DebuffTypeColor then
+	DebuffTypeColor = {
+		["Magic"]   = DEBUFF_TYPE_MAGIC_COLOR   or {r = 0.20, g = 0.60, b = 1.00},
+		["Curse"]   = DEBUFF_TYPE_CURSE_COLOR   or {r = 0.60, g = 0.00, b = 1.00},
+		["Disease"] = DEBUFF_TYPE_DISEASE_COLOR or {r = 0.60, g = 0.40, b = 0.00},
+		["Poison"]  = DEBUFF_TYPE_POISON_COLOR  or {r = 0.00, g = 0.60, b = 0.00},
+		["none"]    = DEBUFF_TYPE_NONE_COLOR    or {r = 0.80, g = 0.00, b = 0.00},
+		[""]        = DEBUFF_TYPE_NONE_COLOR    or {r = 0.80, g = 0.00, b = 0.00},
+	}
+end
+
 local L = ShadowUF.L
 ShadowUF.dbRevision = 61
 ShadowUF.dbRevisionClassic = 6
@@ -687,6 +702,7 @@ end
 local function basicHideBlizzardFrames(...)
 	for i=1, select("#", ...) do
 		local frame = select(i, ...)
+		if not frame then break end
 		frame:UnregisterAllEvents()
 		frame:HookScript("OnShow", rehideFrame)
 		frame:Hide()
@@ -696,6 +712,7 @@ end
 local function hideBlizzardFrames(taint, ...)
 	for i=1, select("#", ...) do
 		local frame = select(i, ...)
+		if not frame then break end
 		UnregisterUnitWatch(frame)
 		frame:UnregisterAllEvents()
 		frame:Hide()
@@ -716,8 +733,9 @@ end
 
 local active_hiddens = {}
 function ShadowUF:HideBlizzardFrames()
+	if not self.db then return end
 	if( self.db.profile.hidden.cast and not active_hiddens.cast ) then
-		hideBlizzardFrames(true, CastingBarFrame, PetCastingBarFrame)
+		hideBlizzardFrames(true, PlayerCastingBarFrame or CastingBarFrame, PetCastingBarFrame)
 	end
 
 	if( self.db.profile.hidden.party and not active_hiddens.party ) then

--- a/modules/auras.lua
+++ b/modules/auras.lua
@@ -680,12 +680,12 @@ function Auras:Update(frame)
 		scan(frame.auras, frame.auras.anchor, frame.auras.primary, config[frame.auras.primary], config[frame.auras.primary], frame.auras[frame.auras.primary].filter)
 		scan(frame.auras, frame.auras.anchor, frame.auras.secondary, config[frame.auras.secondary], config[frame.auras.primary], frame.auras[frame.auras.secondary].filter)
 	else
-		if( config.buffs.enabled ) then
+		if( config.buffs.enabled and frame.auras.buffs ) then
 			frame.auras.buffs.totalAuras = frame.auras.buffs.temporaryEnchants
 			scan(frame.auras, frame.auras.buffs, "buffs", config.buffs, config.buffs, frame.auras.buffs.filter)
 		end
 
-		if( config.debuffs.enabled ) then
+		if( config.debuffs.enabled and frame.auras.debuffs ) then
 			frame.auras.debuffs.totalAuras = 0
 			scan(frame.auras, frame.auras.debuffs, "debuffs", config.debuffs, config.debuffs, frame.auras.debuffs.filter)
 		end

--- a/modules/basecombopoints.lua
+++ b/modules/basecombopoints.lua
@@ -183,11 +183,13 @@ function Combo:Update(frame, event, unit, powerType)
 		ShadowUF.Layout:SetBarVisibility(frame, key, ShadowUF.db.profile.units[frame.unitType][key].showAlways or (points and points > 0))
 	end
 
-	for id, pointTexture in pairs(frame[key].points) do
-		if( id <= points ) then
-			pointTexture:Show()
-		else
-			pointTexture:Hide()
+	if frame[key].points then
+		for id, pointTexture in pairs(frame[key].points) do
+			if( id <= points ) then
+				pointTexture:Show()
+			else
+				pointTexture:Hide()
+			end
 		end
 	end
 end

--- a/modules/incheal.lua
+++ b/modules/incheal.lua
@@ -31,9 +31,19 @@ function IncHeal:OnLayoutApplied(frame)
 	bar.total = nil
 
 	bar:SetSize(frame.healthBar:GetSize())
-	bar:SetStatusBarTexture(ShadowUF.Layout.mediaPath.statusbar)
+
+	local statusbar = ShadowUF.Layout.mediaPath.statusbar
+	if statusbar and statusbar ~= "" then
+		bar:SetStatusBarTexture(statusbar)
+	end
+
 	bar:SetStatusBarColor(ShadowUF.db.profile.healthColors[self.colorKey].r, ShadowUF.db.profile.healthColors[self.colorKey].g, ShadowUF.db.profile.healthColors[self.colorKey].b, ShadowUF.db.profile.bars.alpha)
-	bar:GetStatusBarTexture():SetHorizTile(false)
+
+	local statusBarTexture = bar:GetStatusBarTexture()
+	if statusBarTexture then
+		statusBarTexture:SetHorizTile(false)
+	end
+
 	bar:SetOrientation(frame.healthBar:GetOrientation())
 	bar:SetReverseFill(frame.healthBar:GetReverseFill())
 	bar:Hide()

--- a/modules/layout.lua
+++ b/modules/layout.lua
@@ -372,8 +372,14 @@ function Layout:SetupBars(frame, config)
 			end
 
 			if( ( widget:IsShown() or ( not frame[key].visibilityManaged and module.defaultVisibility == false ) ) and widget.SetStatusBarTexture ) then
-				widget:SetStatusBarTexture(mediaPath.statusbar)
-				widget:GetStatusBarTexture():SetHorizTile(false)
+				if mediaPath.statusbar and mediaPath.statusbar ~= "" then
+					widget:SetStatusBarTexture(mediaPath.statusbar)
+				end
+
+				local statusBarTexture = widget:GetStatusBarTexture()
+				if statusBarTexture then
+					statusBarTexture:SetHorizTile(false)
+				end
 
 				widget:SetOrientation(config[key].vertical and "VERTICAL" or "HORIZONTAL")
 				widget:SetReverseFill(config[key].reverse and true or false)

--- a/modules/runes.lua
+++ b/modules/runes.lua
@@ -49,7 +49,12 @@ function Runes:OnLayoutApplied(frame)
 		rune.background:SetTexture(ShadowUF.Layout.mediaPath.statusbar)
 		rune.background:SetHorizTile(false)
 		rune:SetStatusBarTexture(ShadowUF.Layout.mediaPath.statusbar)
-		rune:GetStatusBarTexture():SetHorizTile(false)
+
+		local statusBarTexture = rune:GetStatusBarTexture()
+		if statusBarTexture then
+			statusBarTexture:SetHorizTile(false)
+		end
+
 		rune:SetWidth(barWidth)
 
 		frame:SetBlockColor(rune, "runeBar", 0.5, 0.5, 0.5)


### PR DESCRIPTION
## What
WoW MoP Classic 5.5.4 (build 68016) backported several retail API/UI changes that break Shadowed Unit Frames on the classic line. This adds minimal guards/fallbacks so it runs cleanly on 5.5.4.

This targets the **classic** branch — the line that actually supports MoP Classic. It supersedes #69, which mistakenly targeted `master` (retail); see that PR for the full testing history.

## Fixes
- **DebuffTypeColor**: rebuilt from the new `DEBUFF_TYPE_*_COLOR` globals when the old table is absent, keeping correct per-type debuff border colours instead of hardcoding values.
- **`hideBlizzardFrames` / `basicHideBlizzardFrames`**: guard nil frames (some class-resource frames don't exist in this build).
- **`HideBlizzardFrames`**: bail if `self.db` isn't ready yet; use `PlayerCastingBarFrame or CastingBarFrame` for the cast bar.
- **auras**: guard `frame.auras.buffs` / `.debuffs` before indexing.
- **incheal / layout / runes**: guard `widget:GetStatusBarTexture()` (nil before a texture is set) and skip empty statusbar texture paths.
- **basecombopoints**: guard `frame[key].points` before iterating.

## Download (testers without git)
The raw GitHub source ZIP does **not** include the bundled libraries (`libs/` are externals), which causes a wave of Lua errors on load. Use this **pre-packaged build instead** — it includes `libs/` and both addon folders:

➡️ **[ShadowedUnitFrames-mop554-classic.zip](https://github.com/HydraxSkarrag/ShadowedUnitFrames/releases/download/mop554-classic-test/ShadowedUnitFrames-mop554-classic.zip)**

Extract into `World of Warcraft/_classic_/Interface/AddOns/` (contains `ShadowedUnitFrames/` and `ShadowedUF_Options/`), overwrite if prompted.

## Testing
Running on a live MoP Classic 5.5.4 install — raiding on a Warlock with no issues, and verified smooth on a Feral Druid and Elemental Shaman as well.
