### PR TITLE
fix: TBC Anniversary patch 2.5.6 (Interface 20506) compatibility

### DIFF
--- a/ExternalAPI.lua
+++ b/ExternalAPI.lua
@@ -4,6 +4,25 @@
 ShadowUF = select(2, ...)
 ShadowUF.API = {}
 
+-- 2.5.6 (patch 20506) compatibility: DebuffTypeColor was removed from the global
+-- environment and replaced with individual DEBUFF_TYPE_*_COLOR constants.
+-- Reconstruct the table so all modules (auras, health, highlight) that reference
+-- DebuffTypeColor continue to work without modification.
+-- Keys used by this addon:
+--   .none / ["none"]  -- auras.lua fallback for unknown debuff type
+--   [""]              -- highlight.lua fallback (DebuffTypeColor[""])
+--   "Magic", "Curse", "Disease", "Poison" -- school types returned by UnitAura
+if not DebuffTypeColor then
+	DebuffTypeColor = {
+		none    = DEBUFF_TYPE_NONE_COLOR    or { r = 0.80, g = 0.00, b = 0.00 },
+		[""]    = DEBUFF_TYPE_NONE_COLOR    or { r = 0.80, g = 0.00, b = 0.00 },
+		Magic   = DEBUFF_TYPE_MAGIC_COLOR   or { r = 0.20, g = 0.60, b = 1.00 },
+		Curse   = DEBUFF_TYPE_CURSE_COLOR   or { r = 0.60, g = 0.00, b = 1.00 },
+		Disease = DEBUFF_TYPE_DISEASE_COLOR or { r = 0.60, g = 0.40, b = 0.00 },
+		Poison  = DEBUFF_TYPE_POISON_COLOR  or { r = 0.00, g = 0.60, b = 0.00 },
+	}
+end
+
 -- Threat colors
 function ShadowUF.API.GetThreatStatusColor(state)
 	if( state == 3 ) then

--- a/ShadowedUnitFrames.toc
+++ b/ShadowedUnitFrames.toc
@@ -1,4 +1,4 @@
-## Interface: 11508,20505,50503
+## Interface: 11508,20505,20506,50503
 ## Title: Shadowed Unit Frames
 ## Notes: Moooooooooooooooooo
 ## Author: Shadowed

--- a/options/ShadowedUF_Options.toc
+++ b/options/ShadowedUF_Options.toc
@@ -1,4 +1,4 @@
-## Interface: 11508,20505,50503
+## Interface: 11508,20505,20506,50503
 ## Title: Shadowed UF (Options)
 ## Notes: Configuration for Shadowed Unit Frames.
 ## Author: Shadowed


### PR DESCRIPTION
## Problem

TBC Anniversary patch 2.5.6 (Interface 20506) removed the `DebuffTypeColor` global table and replaced it with individual `DEBUFF_TYPE_*_COLOR` constants. Any reference to `DebuffTypeColor` now returns `nil`, which causes the following error on every `FullUpdate` call:

```
auras.lua:562: attempt to index global 'DebuffTypeColor' (a nil value)
```

This aborts the entire unit frame update, leaving target frames with no names, no bars, and no buffs/debuffs shown.

## Solution

Reconstruct `DebuffTypeColor` from the new per-school constants in `ExternalAPI.lua` (which is loaded first per the TOC), guarded by `if not DebuffTypeColor then` so the shim is a no-op on older client versions that still provide the global.

Keys reconstructed:
- `.none` / `[""]` — fallback used in `auras.lua` and `highlight.lua`
- `"Magic"`, `"Curse"`, `"Disease"`, `"Poison"` — school types returned by `UnitAura`

Both TOC files also add `20506` to the `## Interface` list so the client loads the addon without an out-of-date warning.

## Files changed

| File | Change |
|---|---|
| `ExternalAPI.lua` | Add `DebuffTypeColor` compat shim (guarded by `if not DebuffTypeColor`) |
| `ShadowedUnitFrames.toc` | Add `20506` to `## Interface` list |
| `options/ShadowedUF_Options.toc` | Add `20506` to `## Interface` list |

## Testing

Tested on TBC Anniversary build 68575 (Interface 20506) — debuff colors, aura display, and unit frame names all work correctly after this patch.
